### PR TITLE
Add: プロフィール編集画面の追加

### DIFF
--- a/src/components/parts/Alert.vue
+++ b/src/components/parts/Alert.vue
@@ -1,0 +1,34 @@
+<!-- VuetifyのAlertsコンポーネントを使用 -->
+<!-- https://next.vuetifyjs.com/en/components/alerts/ -->
+
+<template>
+  <div v-if="hasAlertMessage">
+    <v-alert :color="alertColor" :type="alertStore.type">{{
+      alertStore.message
+    }}</v-alert>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useAlertStore } from "@/stores/alert";
+
+const alertStore = useAlertStore();
+
+const hasAlertMessage = computed(() => {
+  return alertStore.message !== null;
+});
+
+const alertColor = computed(() => {
+  if (alertStore.type === "success") {
+    return "green";
+  } else if (alertStore.type === "info") {
+    return "blue";
+  } else if (alertStore.type === "warning") {
+    return "orange";
+  } else {
+    //alertStore.type === "error"
+    return "red";
+  }
+});
+</script>

--- a/src/components/parts/Alert.vue
+++ b/src/components/parts/Alert.vue
@@ -1,34 +1,29 @@
-<!-- VuetifyのAlertsコンポーネントを使用 -->
-<!-- https://next.vuetifyjs.com/en/components/alerts/ -->
+<!-- VuetifyのSnackbarsコンポーネントを使用 -->
+<!-- https://next.vuetifyjs.com/en/components/snackbars/ -->
 
 <template>
-  <div v-if="hasAlertMessage">
-    <v-alert :color="alertColor" :type="alertStore.type">{{
-      alertStore.message
-    }}</v-alert>
-  </div>
+  <v-snackbar v-model="snackbar" :color="color" timeout="3000">{{
+    message
+  }}</v-snackbar>
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { onMounted, ref } from "vue";
 import { useAlertStore } from "@/stores/alert";
 
+const snackbar = ref(false);
+const message = ref("");
+const color = ref("");
 const alertStore = useAlertStore();
 
-const hasAlertMessage = computed(() => {
-  return alertStore.message !== null;
-});
-
-const alertColor = computed(() => {
-  if (alertStore.type === "success") {
-    return "green";
-  } else if (alertStore.type === "info") {
-    return "blue";
-  } else if (alertStore.type === "warning") {
-    return "orange";
-  } else {
-    //alertStore.type === "error"
-    return "red";
+const setSnackbar = () => {
+  if (alertStore.message) {
+    snackbar.value = true;
+    message.value = alertStore.message;
+    color.value = alertStore.type;
   }
-});
+};
+
+onMounted(setSnackbar);
+alertStore.$subscribe(setSnackbar);
 </script>

--- a/src/components/parts/Header.vue
+++ b/src/components/parts/Header.vue
@@ -9,7 +9,11 @@
       <div v-if="loggedIn">
         <!-- ログイン時のヘッダー -->
         <v-avatar class="mr-4 ml-10" color="grey-darken-1" size="32">
-          <img :src="authStore.user.image" width="32" height="32" />
+          <img
+            :src="!!authStore.user ? authStore.user.image : ''"
+            width="32"
+            height="32"
+          />
         </v-avatar>
 
         <v-btn v-for="link in links" :key="link" variant="text">
@@ -34,11 +38,15 @@
 
 <script setup>
 import { computed, inject } from "vue";
+import { useRouter } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
+import { useAlertStore } from "@/stores/alert";
 import { removeCookie } from "@/plugins/cookie";
 import LoginButton from "@/components/parts/LoginButton.vue";
 
 const authStore = useAuthStore();
+const alertStore = useAlertStore();
+const router = useRouter();
 
 // ログイン中かどうかを返す算出プロパティ
 // ログイン中であればtrueを返す
@@ -57,10 +65,11 @@ const logout = () => {
       authStore.logout();
       removeCookie();
       // Topへ遷移
-      window.location.href = "/";
+      alertStore.setAlert("ログアウトしました");
+      router.push("/");
     })
     .catch((error) => {
-      alert("ログアウトに失敗しました。");
+      alertStore.setAlert("ログアウトに失敗しました", "error");
     });
 };
 

--- a/src/components/views/Callback.vue
+++ b/src/components/views/Callback.vue
@@ -45,7 +45,7 @@ onMounted(() => {
       const { cookies } = useCookies();
       cookies.set("user", response.data.data);
       alertStore.setAlert("ログインしました");
-      router.push("/");
+      router.push("/mypage");
     })
     .catch((error) => {
       alertStore.setAlert(

--- a/src/components/views/Callback.vue
+++ b/src/components/views/Callback.vue
@@ -4,13 +4,15 @@
 
 <script setup>
 import { useAuthStore } from "@/stores/auth";
-import { useRoute } from "vue-router";
+import { useAlertStore } from "@/stores/alert";
+import { useRoute, useRouter } from "vue-router";
 import { inject, onMounted } from "vue";
 
 // onMountedでDOMが作成された後にログイン処理を実行するようにしている
 onMounted(() => {
   // vue3では$routeでクエリー情報を取得できないので、useRouteを使う
   const route = useRoute();
+  const router = useRouter();
 
   // route.queryには、リダイレクトされた際に付与されたクエリパラメータが格納されている
   // 今回は、access_token、client_id、expiry、uidが格納されている
@@ -29,17 +31,23 @@ onMounted(() => {
   // 共通処理の内容としては、authStoreのtokenをheadersにセットしている。
   const axios = inject("axios");
 
+  const alertStore = useAlertStore();
+
   // auth/validate_tokenにリクエストを送ることで、user情報を取得できる
   axios
     .get("/auth/validate_token")
     .then((respnse) => {
       // responseで取得したuser情報のデータは、'plugins/axios.js'にて
       // storeのuserに格納しているため、ここではTOPページへの遷移のみを行う
-      window.location.href = "/";
+      alertStore.setAlert("ログインしました");
+      router.push("/");
     })
     .catch((error) => {
-      alert("ログインに失敗しました。再度ログインしてください。");
-      window.location.href = "/";
+      alertStore.setAlert(
+        "ログインに失敗しました。再度ログインしてください",
+        "error"
+      );
+      router.push("/");
     });
 });
 </script>

--- a/src/components/views/Idea.vue
+++ b/src/components/views/Idea.vue
@@ -2,6 +2,7 @@
   <Header />
   <v-main class="bg-grey-lighten-3">
     <v-container>
+      <Alert />
       <h1>Idea</h1>
     </v-container>
   </v-main>
@@ -9,4 +10,5 @@
 
 <script setup>
 import Header from "@/components/parts/Header.vue";
+import Alert from "@/components/parts/Alert.vue";
 </script>

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -64,18 +64,18 @@ import { inject, onMounted, ref } from "vue";
 import Header from "@/components/parts/Header.vue";
 import Alert from "@/components/parts/Alert.vue";
 import { useAuthStore } from "@/stores/auth";
+import { toCamelCaseObject } from "@/plugins/convert";
 
 const authStore = useAuthStore();
-
+const axios = inject("axios");
 const myProfile = ref([]);
 
 onMounted(() => {
   // 自分のプロフィール情報を取得
-  const axios = inject("axios");
   axios
     .get(`/profiles/${authStore.user.id}`)
     .then((response) => {
-      myProfile.value = response.data;
+      myProfile.value = toCamelCaseObject(response.data);
     })
     .catch((error) => {
       console.log(error);

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -14,6 +14,9 @@
       <v-card elevation="2">
         <v-card-title>
           {{ authStore.user.name }}
+          <v-chip v-if="!!myProfile.grade">
+            {{ `${myProfile.grade}期生` }}
+          </v-chip>
         </v-card-title>
         <v-card-subtitle>
           {{
@@ -24,33 +27,30 @@
         </v-card-subtitle>
         <v-card-text>
           <div>
-            モチベーション：{{
-              !!myProfile.motivation ? myProfile.motivation : "未設定"
-            }}
-          </div>
-          <div>
-            学習フェーズ：{{ !!myProfile.phase ? myProfile.phase : "未設定" }}
-          </div>
-          <div>
-            チーム開発にコミットできる度合い：{{
+            コミット：{{
               !!myProfile.commitment ? myProfile.commitment : "未設定"
             }}
           </div>
           <div>
-            希望ポジション：{{
+            ポジション：{{
               !!myProfile.position ? myProfile.position : "未設定"
             }}
           </div>
           <div>
-            好きなエディター：{{
+            熱量：{{ !!myProfile.motivation ? myProfile.motivation : "未設定" }}
+          </div>
+          <div>
+            フェーズ：{{ !!myProfile.phase ? myProfile.phase : "未設定" }}
+          </div>
+          <div>
+            好きなエディタ：{{
               !!myProfile.editor ? myProfile.editor : "未設定"
             }}
           </div>
           <div>
-            グレード：{{ !!myProfile.grade ? myProfile.grade : "未設定" }}
-          </div>
-          <div>
-            Mattermost：{{ !!myProfile.grade ? myProfile.grade : "未設定" }}
+            Mattermost URL：{{
+              !!myProfile.timesLink ? myProfile.timesLink : "未設定"
+            }}
           </div>
         </v-card-text>
       </v-card>

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -48,8 +48,8 @@
             }}
           </div>
           <div v-if="!!myProfile.timesLink">
-            Mattermost URL：<a :href="myProfile.timesLink">{{
-              myProfile.timesLink
+            Mattermost URL：<a :href="defaultTimesUrl + myProfile.timesLink">{{
+              defaultTimesUrl + myProfile.timesLink
             }}</a>
           </div>
           <div v-else>Mattermost URL：未設定</div>
@@ -75,6 +75,7 @@ import { toCamelCaseObject } from "@/plugins/convert";
 const authStore = useAuthStore();
 const axios = inject("axios");
 const myProfile = ref([]);
+const defaultTimesUrl = "https://chat.runteq.jp/runteq/channels/";
 
 onMounted(() => {
   // 自分のプロフィール情報を取得

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -4,15 +4,15 @@
     <v-container>
       <Alert />
       <h1>マイページ</h1>
-      <v-avatar color="grey-darken-1" size="144">
-        <img
-          :src="!!authStore.user ? authStore.user.image : ''"
-          width="144"
-          height="144"
-        />
-      </v-avatar>
-      <v-card elevation="2">
+      <v-card elevation="2" width="100%">
         <v-card-title>
+          <v-avatar color="grey-darken-1" size="96">
+            <img
+              :src="!!authStore.user ? authStore.user.image : ''"
+              width="96"
+              height="96"
+            />
+          </v-avatar>
           {{ authStore.user.name }}
           <v-chip v-if="!!myProfile.grade">
             {{ `${myProfile.grade}期生` }}
@@ -47,14 +47,20 @@
               !!myProfile.editor ? myProfile.editor : "未設定"
             }}
           </div>
-          <div>
-            Mattermost URL：{{
-              !!myProfile.timesLink ? myProfile.timesLink : "未設定"
-            }}
+          <div v-if="!!myProfile.timesLink">
+            Mattermost URL：<a :href="myProfile.timesLink">{{
+              myProfile.timesLink
+            }}</a>
           </div>
+          <div v-else>Mattermost URL：未設定</div>
         </v-card-text>
+        <v-divider></v-divider>
+        <v-card-actions>
+          <v-btn color="success" :to="{ name: 'Profile' }">
+            プロフィール編集
+          </v-btn>
+        </v-card-actions>
       </v-card>
-      <v-btn :to="{ name: 'Profile' }" elevation="3">プロフィール編集</v-btn>
     </v-container>
   </v-main>
 </template>

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -2,6 +2,7 @@
   <Header />
   <v-main class="bg-grey-lighten-3">
     <v-container>
+      <Alert />
       <h1>Mypage</h1>
     </v-container>
   </v-main>
@@ -9,4 +10,5 @@
 
 <script setup>
 import Header from "@/components/parts/Header.vue";
+import Alert from "@/components/parts/Alert.vue";
 </script>

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -3,12 +3,82 @@
   <v-main class="bg-grey-lighten-3">
     <v-container>
       <Alert />
-      <h1>Mypage</h1>
+      <h1>マイページ</h1>
+      <v-avatar color="grey-darken-1" size="144">
+        <img
+          :src="!!authStore.user ? authStore.user.image : ''"
+          width="144"
+          height="144"
+        />
+      </v-avatar>
+      <v-card elevation="2">
+        <v-card-title>
+          {{ authStore.user.name }}
+        </v-card-title>
+        <v-card-subtitle>
+          {{
+            !!myProfile.selfIntroduction
+              ? myProfile.selfIntroduction
+              : "自己紹介文が設定されていません"
+          }}
+        </v-card-subtitle>
+        <v-card-text>
+          <div>
+            モチベーション：{{
+              !!myProfile.motivation ? myProfile.motivation : "未設定"
+            }}
+          </div>
+          <div>
+            学習フェーズ：{{ !!myProfile.phase ? myProfile.phase : "未設定" }}
+          </div>
+          <div>
+            チーム開発にコミットできる度合い：{{
+              !!myProfile.commitment ? myProfile.commitment : "未設定"
+            }}
+          </div>
+          <div>
+            希望ポジション：{{
+              !!myProfile.position ? myProfile.position : "未設定"
+            }}
+          </div>
+          <div>
+            好きなエディター：{{
+              !!myProfile.editor ? myProfile.editor : "未設定"
+            }}
+          </div>
+          <div>
+            グレード：{{ !!myProfile.grade ? myProfile.grade : "未設定" }}
+          </div>
+          <div>
+            Mattermost：{{ !!myProfile.grade ? myProfile.grade : "未設定" }}
+          </div>
+        </v-card-text>
+      </v-card>
+      <v-btn :to="{ name: 'Profile' }" elevation="3">プロフィール編集</v-btn>
     </v-container>
   </v-main>
 </template>
 
 <script setup>
+import { inject, onMounted, ref } from "vue";
 import Header from "@/components/parts/Header.vue";
 import Alert from "@/components/parts/Alert.vue";
+import { useAuthStore } from "@/stores/auth";
+
+const authStore = useAuthStore();
+
+const myProfile = ref([]);
+
+onMounted(() => {
+  // 自分のプロフィール情報を取得
+  const axios = inject("axios");
+  axios
+    .get(`/profiles/${authStore.user.id}`)
+    .then((response) => {
+      myProfile.value = response.data;
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+});
 </script>

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -30,6 +30,11 @@
           </div>
           <div v-else>Mattermost URL：未設定</div>
         </v-card-text>
+        <v-card-text>
+          <v-chip v-for="tag in myProfile.tags">
+            {{ tag }}
+          </v-chip>
+        </v-card-text>
         <v-divider></v-divider>
         <v-card-actions>
           <v-btn color="success" :to="{ name: 'Profile' }">
@@ -42,15 +47,25 @@
 </template>
 
 <script setup>
-import { inject, onMounted, ref } from "vue";
+import { inject, onMounted, reactive } from "vue";
 import Header from "@/components/parts/Header.vue";
 import Alert from "@/components/parts/Alert.vue";
 import { useAuthStore } from "@/stores/auth";
-import { toCamelCaseObject } from "@/plugins/convert";
+import { toUnderscoreCase } from "@/plugins/convert";
 
 const authStore = useAuthStore();
 const axios = inject("axios");
-const myProfile = ref([]);
+const myProfile = reactive({
+  selfIntroduction: "",
+  grade: "",
+  commitment: "",
+  position: "",
+  motivation: "",
+  phase: "",
+  editor: "",
+  timesLink: "",
+  tags: [],
+});
 const defaultTimesUrl = "https://chat.runteq.jp/runteq/channels/";
 
 onMounted(() => {
@@ -58,7 +73,13 @@ onMounted(() => {
   axios
     .get(`/profiles/${authStore.user.id}`)
     .then((response) => {
-      myProfile.value = toCamelCaseObject(response.data);
+      Object.keys(myProfile).forEach((key) => {
+        if (key === "tags") {
+          myProfile[key] = response.data[key].map((obj) => obj.name);
+        } else {
+          myProfile[key] = response.data.profile[toUnderscoreCase(key)];
+        }
+      });
     })
     .catch((error) => {
       console.log(error);

--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -7,49 +7,25 @@
       <v-card elevation="2" width="100%">
         <v-card-title>
           <v-avatar color="grey-darken-1" size="96">
-            <img
-              :src="!!authStore.user ? authStore.user.image : ''"
-              width="96"
-              height="96"
-            />
+            <img :src="authStore?.user?.image || ''" width="96" height="96" />
           </v-avatar>
-          {{ authStore.user.name }}
-          <v-chip v-if="!!myProfile.grade">
-            {{ `${myProfile.grade}期生` }}
+          {{ authStore?.user?.name }}
+          <v-chip v-if="!!myProfile?.grade">
+            {{ `${myProfile?.grade}期生` }}
           </v-chip>
         </v-card-title>
         <v-card-subtitle>
-          {{
-            !!myProfile.selfIntroduction
-              ? myProfile.selfIntroduction
-              : "自己紹介文が設定されていません"
-          }}
+          {{ myProfile?.selfIntroduction || "自己紹介文が設定されていません" }}
         </v-card-subtitle>
         <v-card-text>
-          <div>
-            コミット：{{
-              !!myProfile.commitment ? myProfile.commitment : "未設定"
-            }}
-          </div>
-          <div>
-            ポジション：{{
-              !!myProfile.position ? myProfile.position : "未設定"
-            }}
-          </div>
-          <div>
-            熱量：{{ !!myProfile.motivation ? myProfile.motivation : "未設定" }}
-          </div>
-          <div>
-            フェーズ：{{ !!myProfile.phase ? myProfile.phase : "未設定" }}
-          </div>
-          <div>
-            好きなエディタ：{{
-              !!myProfile.editor ? myProfile.editor : "未設定"
-            }}
-          </div>
-          <div v-if="!!myProfile.timesLink">
-            Mattermost URL：<a :href="defaultTimesUrl + myProfile.timesLink">{{
-              defaultTimesUrl + myProfile.timesLink
+          <div>コミット：{{ myProfile?.commitment || "未設定" }}</div>
+          <div>ポジション：{{ myProfile?.position || "未設定" }}</div>
+          <div>熱量：{{ myProfile?.motivation || "未設定" }}</div>
+          <div>フェーズ：{{ myProfile?.phase || "未設定" }}</div>
+          <div>好きなエディタ：{{ myProfile?.editor || "未設定" }}</div>
+          <div v-if="myProfile?.timesLink">
+            Mattermost URL：<a :href="defaultTimesUrl + myProfile?.timesLink">{{
+              defaultTimesUrl + myProfile?.timesLink
             }}</a>
           </div>
           <div v-else>Mattermost URL：未設定</div>

--- a/src/components/views/Profile.vue
+++ b/src/components/views/Profile.vue
@@ -137,7 +137,7 @@ watch(
   () => myProfile.timesLink,
   () => {
     const defaultTimesUrl = "https://chat.runteq.jp/runteq/channels/";
-    if (myProfile.timesLink.startsWith(defaultTimesUrl)) {
+    if (myProfile.timesLink?.startsWith(defaultTimesUrl)) {
       myProfile.timesLink = myProfile.timesLink.replace(defaultTimesUrl, "");
     }
   }

--- a/src/components/views/Profile.vue
+++ b/src/components/views/Profile.vue
@@ -1,0 +1,123 @@
+<template>
+  <Header />
+  <v-main class="bg-grey-lighten-3">
+    <v-container>
+      <Alert />
+      <h1>プロフィール編集</h1>
+      <v-form>
+        <v-text-field
+          v-model="myProfile.selfIntroduction"
+          :counter="100"
+          label="自己紹介文"
+        ></v-text-field>
+        <v-text-field v-model="myProfile.grade" label="何期生か"></v-text-field>
+        <v-select
+          v-model="myProfile.commitment"
+          :items="commitmentItems"
+          label="どのくらいコミットできるか"
+        ></v-select>
+        <v-select
+          v-model="myProfile.position"
+          :items="positionItems"
+          label="どのポジションでチーム開発に関わりたいか"
+        ></v-select>
+        <v-select
+          v-model="myProfile.motivation"
+          :items="motivationItems"
+          label="どれくらいの熱量でチーム開発に関わりたいか"
+        ></v-select>
+        <v-select
+          v-model="myProfile.phase"
+          :items="phaseItems"
+          label="どのフェーズか"
+        ></v-select>
+        <v-select
+          v-model="myProfile.editor"
+          :items="editorItems"
+          label="好きなエディタ"
+        ></v-select>
+        <v-text-field
+          v-model="myProfile.timesLink"
+          :counter="100"
+          label="MattermostのtimesのURL"
+        ></v-text-field>
+        <v-btn class="mr-2" color="success" @click="submit"> 更新 </v-btn>
+        <v-btn :to="{ name: 'Mypage' }"> 戻る </v-btn>
+      </v-form>
+    </v-container>
+  </v-main>
+</template>
+
+<script setup>
+import { inject, onMounted, ref } from "vue";
+import Header from "@/components/parts/Header.vue";
+import Alert from "@/components/parts/Alert.vue";
+import { useAuthStore } from "@/stores/auth";
+import { useAlertStore } from "@/stores/alert";
+import { useRouter } from "vue-router";
+import { toCamelCaseObject, toUnderscoreCaseObject } from "@/plugins/convert";
+
+const authStore = useAuthStore();
+const alertStore = useAlertStore();
+const axios = inject("axios");
+const router = useRouter();
+const myProfile = ref([]);
+
+onMounted(() => {
+  // 自分のプロフィール情報を取得
+  axios
+    .get(`/profiles/${authStore.user.id}`)
+    .then((response) => {
+      myProfile.value = toCamelCaseObject(response.data);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+});
+
+const commitmentItems = ["週1回", "週2〜3回", "週4〜5回", "毎日"];
+const positionItems = [
+  "バックエンド",
+  "フロントエンド",
+  "レビュー",
+  "アドバイザー",
+  "希望なし",
+];
+const motivationItems = [
+  "ガチで作成したい",
+  "ゆるく楽しく作成したい",
+  "サポートしたい",
+];
+const phaseItems = ["カリキュラム中", "PF作成中", "就活中", "現役エンジニア"];
+const editorItems = [
+  "Visual Studio Code",
+  "Atom",
+  "Vim",
+  "NoEditor",
+  "Sublime Text",
+];
+
+const submit = () => {
+  // 値が入っていないパラメータを省く
+  const params = Object.entries(myProfile.value).reduce((prev, next) => {
+    const [key, value] = next;
+    if (!!value) {
+      prev[key] = value;
+    }
+    return prev;
+  }, {});
+  console.log(params);
+  axios
+    .patch(`/profiles/${authStore.user.id}`, {
+      profile: toUnderscoreCaseObject(params),
+    })
+    .then(() => {
+      alertStore.setAlert("プロフィールを更新しました");
+      router.push("/mypage");
+    })
+    .catch((error) => {
+      alertStore.setAlert("プロフィールの更新に失敗しました", "error");
+      console.log(error);
+    });
+};
+</script>

--- a/src/components/views/Profile.vue
+++ b/src/components/views/Profile.vue
@@ -49,6 +49,27 @@
           :rules="[lessThan50CharactersValidation, urlValidation]"
           prefix="https://chat.runteq.jp/runteq/channels/"
         ></v-text-field>
+        <v-combobox
+          v-model="myProfile.tags"
+          :items="tagItems"
+          chips
+          clearable
+          label="タグ"
+          multiple
+          prepend-icon="mdi-filter-variant"
+          solo
+        >
+          <template v-slot:selection="{ attrs, item, select, selected }">
+            <v-chip
+              v-bind="attrs"
+              :input-value="selected"
+              close
+              @click="select"
+            >
+              {{ item }}
+            </v-chip>
+          </template>
+        </v-combobox>
         <v-btn class="mr-2" color="success" @click="submit"> 更新 </v-btn>
         <v-btn :to="{ name: 'Mypage' }"> 戻る </v-btn>
       </v-form>
@@ -63,12 +84,13 @@ import Alert from "@/components/parts/Alert.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useAlertStore } from "@/stores/alert";
 import { useRouter } from "vue-router";
-import { toCamelCaseObject, toUnderscoreCaseObject } from "@/plugins/convert";
+import { toUnderscoreCase, toUnderscoreCaseObject } from "@/plugins/convert";
 
 const authStore = useAuthStore();
 const alertStore = useAlertStore();
 const axios = inject("axios");
 const router = useRouter();
+const form = ref(null);
 const myProfile = reactive({
   selfIntroduction: "",
   grade: "",
@@ -78,24 +100,8 @@ const myProfile = reactive({
   phase: "",
   editor: "",
   timesLink: "",
+  tags: [],
 });
-
-onMounted(() => {
-  // 自分のプロフィール情報を取得
-  axios
-    .get(`/profiles/${authStore.user.id}`)
-    .then((response) => {
-      const responseObject = toCamelCaseObject(response.data);
-      Object.keys(myProfile).forEach((key) => {
-        myProfile[key] = responseObject[key];
-      });
-    })
-    .catch((error) => {
-      console.log(error);
-    });
-});
-
-const form = ref(null);
 
 // フォームの選択肢
 const commitmentItems = ["週1回", "週2〜3回", "週4〜5回", "毎日"];
@@ -119,6 +125,7 @@ const editorItems = [
   "NoEditor",
   "Sublime Text",
 ];
+const tagItems = ref([]);
 
 // バリデーション
 const lessThan100CharactersValidation = (value) =>
@@ -143,6 +150,35 @@ watch(
   }
 );
 
+onMounted(() => {
+  // タグ一覧を取得
+  axios
+    .get(`/tags`)
+    .then((response) => {
+      Object.keys(response.data).forEach((key) => {
+        tagItems.value.push(response.data[key].name);
+      });
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+  // 自分のプロフィール情報を取得
+  axios
+    .get(`/profiles/${authStore.user.id}`)
+    .then((response) => {
+      Object.keys(myProfile).forEach((key) => {
+        if (key === "tags") {
+          myProfile[key] = response.data[key].map((obj) => obj.name);
+        } else {
+          myProfile[key] = response.data.profile[toUnderscoreCase(key)];
+        }
+      });
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+});
+
 const submit = () => {
   form.value.validate().then((data) => {
     if (!data.valid) {
@@ -151,10 +187,12 @@ const submit = () => {
       return;
     }
     // バリデーションに成功した場合
-    // 値が入っていないパラメータを省く
+    // パラメータの変換
     const params = Object.entries(myProfile).reduce((prev, next) => {
       const [key, value] = next;
-      if (!!value) {
+      if (key === "tags") {
+        prev[key] = value.join(",");
+      } else {
         prev[key] = value;
       }
       return prev;

--- a/src/components/views/Top.vue
+++ b/src/components/views/Top.vue
@@ -2,6 +2,7 @@
   <Header />
   <v-main class="bg-grey-lighten-3">
     <v-container>
+      <Alert />
       <h1>Top</h1>
       <div v-if="!loggedIn"><LoginButton /></div>
     </v-container>
@@ -13,6 +14,7 @@ import { computed } from "vue";
 import { useAuthStore } from "@/stores/auth";
 import Header from "@/components/parts/Header.vue";
 import LoginButton from "@/components/parts/LoginButton.vue";
+import Alert from "@/components/parts/Alert.vue";
 
 const authStore = useAuthStore();
 

--- a/src/components/views/User.vue
+++ b/src/components/views/User.vue
@@ -2,6 +2,7 @@
   <Header />
   <v-main class="bg-grey-lighten-3">
     <v-container>
+      <Alert />
       <h1>User</h1>
     </v-container>
   </v-main>
@@ -9,6 +10,7 @@
 
 <script>
 import Header from "@/components/parts/Header.vue";
+import Alert from "@/components/parts/Alert.vue";
 
 export default {
   components: { Header },

--- a/src/plugins/convert.js
+++ b/src/plugins/convert.js
@@ -1,0 +1,41 @@
+// APIとの通信時、キャメルケースとスネークケースを変換したいときに使用
+// 参考：https://www.yoheim.net/blog.php?q=20181204
+
+// スネークケースからキャメルケースに変換（文字列）.
+export function toCamelCase(str) {
+  return str
+    .split("_")
+    .map(function (word, index) {
+      if (index === 0) {
+        return word.toLowerCase();
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join("");
+}
+
+// スネークケースからキャメルケースに変換（オブジェクト）.
+export function toCamelCaseObject(obj) {
+  const result = {};
+  Object.keys(obj).forEach((key) => {
+    result[toCamelCase(key)] = obj[key];
+  });
+  return result;
+}
+
+// キャメルケースからスネークケースに変換（文字列）.
+export function toUnderscoreCase(str) {
+  return str
+    .split(/(?=[A-Z])/)
+    .join("_")
+    .toLowerCase();
+}
+
+// キャメルケースからスネークケースに変換（オブジェクト）.
+export function toUnderscoreCaseObject(obj) {
+  const result = {};
+  Object.keys(obj).forEach((key) => {
+    result[toUnderscoreCase(key)] = obj[key];
+  });
+  return result;
+}

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -4,6 +4,7 @@ import Top from "@/components/views/Top.vue";
 import Mypage from "@/components/views/Mypage.vue";
 import User from "@/components/views/User.vue";
 import Idea from "@/components/views/Idea.vue";
+import Profile from "@/components/views/Profile.vue";
 
 const routes = [
   {
@@ -30,6 +31,11 @@ const routes = [
     path: "/idea",
     name: "Idea",
     component: Idea,
+  },
+  {
+    path: "/profile",
+    name: "Profile",
+    component: Profile,
   },
 ];
 

--- a/src/stores/alert.js
+++ b/src/stores/alert.js
@@ -6,14 +6,14 @@ export const useAlertStore = defineStore("alert", {
     type: null, //success, info, warning, errorの4種類
   }),
   actions: {
-    setAlert(message, type = "success", timeout = 3000) {
+    setAlert(message, type = "success") {
       this.message = message;
       this.type = type;
 
-      // timeoutミリ秒が経過するとリセットされる
+      // 3000ミリ秒が経過するとリセットされる
       setTimeout(() => {
         this.$reset();
-      }, timeout);
+      }, 3000);
     },
   },
 });

--- a/src/stores/alert.js
+++ b/src/stores/alert.js
@@ -1,0 +1,19 @@
+import { defineStore } from "pinia";
+
+export const useAlertStore = defineStore("alert", {
+  state: () => ({
+    message: null,
+    type: null, //success, info, warning, errorの4種類
+  }),
+  actions: {
+    setAlert(message, type = "success", timeout = 3000) {
+      this.message = message;
+      this.type = type;
+
+      // timeoutミリ秒が経過するとリセットされる
+      setTimeout(() => {
+        this.$reset();
+      }, timeout);
+    },
+  },
+});


### PR DESCRIPTION
# Issue
#9 

デカプルリクになり申し訳なく思っております。
プロフィール編集画面を実装しました。
とりあえず動くものを！という思いで、デザインは全面的に後回しになっておりますがご容赦ください。

# やったこと
- アラート（フラッシュメッセージ）機能の実装
    - 該当部分：`src/stores/alert.js` `src/components/parts/Alert.vue`
    - 使い方
        - アラートを設定する：`useAlertStore`を呼び出してアラートメッセージなどの値を`alertStore`に保存、3秒経過後に値がリセットされます。
        - アラートを表示させる：`Alert`コンポーネントをページ内に組み込んでいれば、`alertStore`に値が入っているときは画面上にアラートが表示されます。
    - 今あるページにはすべて`Alert`コンポーネントを組み入れました。
    - ログイン、ログアウト時にアラートが出るように修正しました。
        - `window.location.href`による遷移だとアラートの状態が保存されなかったので、`useRouter`で遷移するように変更しました。
- プロフィール編集機能の実装
    - 該当部分：`src/components/views/Profile.vue`
    - 選択肢やバリデーションの要件は https://github.com/NewBeLab/NewBeLab-Rails/issues/6 に従いました。
    - Rails APIとの通信においてキャメルケースとスネークケースを変換したいときのために、 `src/plugins/convert.js`を追加しました。
- マイページに簡単なプロフィール項目を追加
    - 該当部分：`src/components/views/Mypage.vue`

# 動作確認

更新成功ケース

https://user-images.githubusercontent.com/97581501/208108850-7a904dad-ca88-464f-9b50-129224771bdc.mov

更新失敗ケース

https://user-images.githubusercontent.com/97581501/208108866-3fbdf41b-9c4b-48f9-80af-99aa777eff5e.mov

# 確認してほしい点
- プロフィール編集機能が正しく動くかどうか
    - そもそもAPIの宛先って`api/v1/profiles/:user_id`でよかったでしたっけ・・・
    - Rails側でProfileモデルとUserモデルのidが違う可能性がある・・・？
- `src/components/views/Profile.vue`の`submit()`処理の書き方が妥当かどうか
    - promise〜thenが入れ子になってて、JSの書き方として変かも？
- アラートが指定秒数後に消える仕組みが妥当かどうか
    - 一度アラートを表示させたら、画面が変わるまで消えないほうがよい？
    - いきなりヒュンっと消えるのも変かも
        - transitionを設定すればもう少し自然に見えそうなんですが、なんか上手くいきませんでした涙
- `src/plugins/convert.js`に書いたメソッド群の配置はここで妥当かどうか 