### PR TITLE
fixed 自己紹介を改行できるよう変更

### DIFF
--- a/src/components/views/Mypage.vue
+++ b/src/components/views/Mypage.vue
@@ -14,7 +14,7 @@
             {{ `${myProfile?.grade}期生` }}
           </v-chip>
         </v-card-title>
-        <v-card-subtitle>
+        <v-card-subtitle class="mt-3" style="white-space: pre-wrap;">
           {{ myProfile?.selfIntroduction || "自己紹介文が設定されていません" }}
         </v-card-subtitle>
         <v-card-text>

--- a/src/components/views/Profile.vue
+++ b/src/components/views/Profile.vue
@@ -5,12 +5,14 @@
       <Alert />
       <p class="text-h4 my-12 ml-5">プロフィール編集</p>
       <v-form ref="form">
-        <v-text-field
+        <v-textarea
           v-model="myProfile.selfIntroduction"
           :counter="100"
           label="自己紹介文"
           :rules="[lessThan100CharactersValidation]"
-        ></v-text-field>
+          auto-grow
+          rows="1"
+        ></v-textarea>
         <v-text-field
           v-model="myProfile.grade"
           label="何期生か"

--- a/src/components/views/User.vue
+++ b/src/components/views/User.vue
@@ -52,7 +52,7 @@
             <v-card-title class="text-h6 ml-4 font-weight-bold">
               自己紹介
             </v-card-title>
-            <p class="text-body-1 mx-8 pb-0 font-weight-thin">
+            <p class="text-body-1 mx-8 pb-0 font-weight-thin" style="white-space: pre-wrap;">
               {{ profile?.profile.selfIntroduction || "未設定😭" }}
             </p>
             <v-divider insent class="mt-4 mx-6" />


### PR DESCRIPTION
# issue
#9

# やったこと
自己紹介(selfIntroduction)を改行できるように修正しました。

# 動作確認
- ### `/profile`の表示
<img width="600" alt="NewBeLab" src="https://user-images.githubusercontent.com/62694188/216674649-41bd5863-d378-45bc-b50e-effba46bd27c.png">

- ### `/mypage`の表示
<img width="600" alt="NewBeLab" src="https://user-images.githubusercontent.com/62694188/216674755-baa28f0c-b97b-427d-b96b-d954dbb70ece.png">

- ### `/user`の表示
<img width="600" alt="NewBeLab" src="https://user-images.githubusercontent.com/62694188/216674859-aacfecce-bae6-4596-9b47-382e0c95df2f.png">
