### PR TITLE
add #4 UserFilter機能の追加

### DIFF
--- a/src/components/parts/UserFilter.vue
+++ b/src/components/parts/UserFilter.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-expansion-panels class="py-10">
+    <v-expansion-panel>
+      <v-expansion-panel-title>
+        <v-row>
+          <v-col cols="3"><p class="text-h6">ユーザー検索</p></v-col>
+        </v-row>
+      </v-expansion-panel-title>
+      <v-expansion-panel-text>
+        <v-row justify="center">
+          <v-col cols="12" sm="6" lg="3">
+            <v-select
+              v-model="searchCommitment"
+              :items="commitments"
+              label="コミット"
+              clearable
+            ></v-select>
+          </v-col>
+          <v-col cols="12" sm="6" lg="3">
+            <v-select
+              v-model="searchMotivation"
+              :items="motivation"
+              label="熱量"
+              clearable
+            ></v-select>
+          </v-col>
+          <v-col cols="12" sm="6" lg="3">
+            <v-select
+              v-model="searchPosition"
+              :items="positions"
+              label="ポジション"
+              clearable
+            ></v-select>
+          </v-col>
+          <v-col cols="12" sm="6" lg="3">
+            <v-select
+              v-model="searchPhase"
+              :items="phase"
+              label="フェーズ"
+              clearable
+            ></v-select>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col offset="11">
+            <v-btn color="primary" @click="$emit('searchFilterProfiles', query)"
+              >検索</v-btn
+            >
+          </v-col>
+        </v-row>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+  </v-expansion-panels>
+</template>
+
+<script setup>
+import { ref, watch } from "vue";
+
+const searchCommitment = ref("");
+const searchMotivation = ref("");
+const searchPosition = ref("");
+const searchPhase = ref("");
+
+const query = ref({});
+
+const commitments = ["週1回", "週2〜3回", "週4〜5回", "毎日"];
+
+const positions = [
+  "バックエンド",
+  "フロントエンド",
+  "レビュー",
+  "アドバイザー",
+  "希望なし",
+];
+
+const motivation = [
+  "ガチで作成したい",
+  "ゆるく楽しく作成したい",
+  "サポートしたい",
+];
+
+const phase = ["カリキュラム中", "PF作成中", "就活中", "現役エンジニア"];
+
+watch(
+  () => [
+    searchCommitment.value,
+    searchMotivation.value,
+    searchPosition.value,
+    searchPhase.value,
+  ],
+  () => {
+    query.value = {
+      commitment_cont: searchCommitment.value,
+      motivation_cont: searchMotivation.value,
+      position_cont: searchPosition.value,
+      phase_cont: searchPhase.value,
+    };
+  }
+);
+</script>

--- a/src/components/views/User.vue
+++ b/src/components/views/User.vue
@@ -3,7 +3,10 @@
   <v-main>
     <v-container>
       <Alert />
-      <p class="text-h4 my-12 ml-5">ユーザー一覧</p>
+      <p class="text-h4 mt-10 ml-5">ユーザー一覧</p>
+
+      <UserFilter @searchFilterProfiles="searchFilterProfiles" />
+
       <v-row width="100%">
         <v-col
           v-for="profile in profiles"
@@ -13,7 +16,7 @@
           sm="6"
           md="6"
           xl="6"
-          class="mb-8"
+          class="mb-5"
         >
           <v-card
             rounded="xl"
@@ -52,7 +55,10 @@
             <v-card-title class="text-h6 ml-4 font-weight-bold">
               自己紹介
             </v-card-title>
-            <p class="text-body-1 mx-8 pb-0 font-weight-thin">
+            <p
+              class="text-body-1 mx-8 pb-0 font-weight-thin"
+              style="white-space: pre-wrap"
+            >
               {{ profile?.profile.selfIntroduction || "未設定😭" }}
             </p>
             <v-divider insent class="mt-4 mx-6" />
@@ -90,7 +96,7 @@
                   v-if="profile.profile.timesLink"
                   >{{ profile.profile.timesLink }}
                 </a>
-                <span v-else style="display:inline">未設定</span>
+                <span v-else style="display: inline">未設定</span>
               </p>
             </v-card-text>
             <v-card-text v-else>
@@ -123,9 +129,9 @@
         :length="totalPages"
         :total-visible="6"
         class="mt-5"
-        @next="fetchProfiles"
-        @prev="fetchProfiles"
-        @click="fetchProfiles"
+        @next="isFilterProfiles ? fetchFilterProfiles(q) : fetchProfiles"
+        @prev="isFilterProfiles ? fetchFilterProfiles(q) : fetchProfiles"
+        @click="isFilterProfiles ? fetchFilterProfiles(q) : fetchProfiles"
       >
       </v-pagination>
     </v-container>
@@ -136,6 +142,7 @@
 import { inject, onMounted, ref, reactive, watch } from "vue";
 import Header from "@/components/parts/Header.vue";
 import Alert from "@/components/parts/Alert.vue";
+import UserFilter from "@/components/parts/UserFilter.vue";
 
 import { useAlertStore } from "@/stores/alert";
 import { toCamelCaseObject } from "@/plugins/convert";
@@ -145,6 +152,8 @@ const axios = inject("axios");
 const profiles = ref([]);
 const page = ref(1);
 const totalPages = ref(0);
+const isFilterProfiles = ref(false);
+const q = ref({});
 
 onMounted(() => {
   fetchProfiles();
@@ -156,7 +165,7 @@ function fetchProfiles() {
       params: {
         page: page.value,
         per: 6,
-        q: { q: ""}
+        q: { q: "" },
       },
     })
     .then(({ data }) => {
@@ -169,6 +178,7 @@ function fetchProfiles() {
         };
       });
       profiles.value = filteredData;
+      isFilterProfiles.value = false;
       window.scrollTo(0, 0);
     })
     .catch((error) =>
@@ -178,6 +188,103 @@ function fetchProfiles() {
       )
     );
 }
+
+function searchFilterProfiles(query) {
+  // ページネーションで利用するためのクエリーを保持
+  q.value = query;
+  // ユーザーフィルターの初回読み込み時に毎回ページを1に戻す
+  page.value = 1;
+  axios
+    .get("/profiles", {
+      params: {
+        page: page.value,
+        per: 6,
+        q: query,
+      },
+    })
+    .then(({ data }) => {
+      totalPages.value = data.total_pages;
+      const filteredData = data.profiles.map((user) => {
+        return {
+          ...user,
+          profile: toCamelCaseObject(user.profile),
+          isShowProfile: true,
+        };
+      });
+      profiles.value = filteredData;
+      isFilterProfiles.value = true;
+      window.scrollTo(0, 0);
+    })
+    .catch((error) =>
+      alertStore.setAlert(
+        "エラーが発生しました。リロードしてください。",
+        "error"
+      )
+    );
+}
+
+// ユーザーフィルター時にページネーションをクリックした時に呼ばれる関数
+function fetchFilterProfiles(q) {
+  axios
+    .get("/profiles", {
+      params: {
+        page: page.value,
+        per: 6,
+        q: q,
+      },
+    })
+    .then(({ data }) => {
+      totalPages.value = data.total_pages;
+      const filteredData = data.profiles.map((user) => {
+        return {
+          ...user,
+          profile: toCamelCaseObject(user.profile),
+          isShowProfile: true,
+        };
+      });
+      profiles.value = filteredData;
+      isFilterProfiles.value = true;
+      window.scrollTo(0, 0);
+    })
+    .catch((error) =>
+      alertStore.setAlert(
+        "エラーが発生しました。リロードしてください。",
+        "error"
+      )
+    );
+}
+
+// 検索結果が0件だった場合に表示する
+function showEmptyProfile() {
+  const emptyProfile = {
+    id: 0,
+    name: "No User 😢",
+    username: "😭",
+    profile: {
+      selfIntroduction:
+        "検索条件に合致するユーザーがいません😭\nゴメンネ・・・😢",
+      commitment: "😭",
+      position: "😭",
+      motivation: "😭",
+      phase: "😭",
+      editor: "😭",
+      timesLink: "😭",
+    },
+    isShowProfile: false,
+    tags: [],
+  };
+  profiles.value = [emptyProfile];
+}
+
+// 検索結果が0件だった場合に表示する
+watch(
+  () => profiles.value,
+  (newProfiles) => {
+    if (newProfiles.length === 0) {
+      showEmptyProfile();
+    }
+  }
+);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# issue
#4 
# やったこと
- ユーザー絞り込み機能の実装
  - ユーザー絞り込み表示は`UserFilter.vue`にコンポーネント化
  - 単体・複数それぞれの条件で絞り込みが可能
  - 検索条件を保持したままページネーション可能
  - 別の検索条件を追加したりすると、再度１ページ目からページネーションされる
  - 検索条件を全てクリアして全ユーザーでの検索を再度すると、ページネーションが１ページ目に戻る

# 動作確認
- ### 単体・複数条件で絞り込める
<img width="600" alt="スクリーンショット 2023-02-05 17 25 04" src="https://user-images.githubusercontent.com/62694188/216808968-f1bf93c4-a739-43e7-aac0-81a830b916c1.png">

- ### 検索条件を保持したままページネーションが可能なことを確認
<img width="600" alt="スクリーンショット 2023-02-05 17 25 32" src="https://user-images.githubusercontent.com/62694188/216809004-f80e0b40-c69a-4610-9252-e08b916a344a.png">


- ### 条件に合致するユーザーがない場合は陳謝する🙇
<img width="600" alt="スクリーンショット 2023-02-05 17 25 40" src="https://user-images.githubusercontent.com/62694188/216809014-eb5e325b-df89-4622-b1b9-222e686398e5.png">
